### PR TITLE
Enable graceful handling of bogus registrations

### DIFF
--- a/server/lib/miaServer.coffee
+++ b/server/lib/miaServer.coffee
@@ -44,7 +44,8 @@ class Server
 			@handleRegistration name, connection, true
 		else if messageCommand == 'UNREGISTER'
 			player = @playerFor connection
-			@handleUnregistration player, connection
+			if player?
+				@handleUnregistration player, connection
 		else
 			player = @playerFor connection
 			player?.handleMessage messageCommand, messageArgs

--- a/server/spec/MiaServerSpec.coffee
+++ b/server/spec/MiaServerSpec.coffee
@@ -55,6 +55,9 @@ describe 'mia server', ->
 		expect(game.unregister).toHaveBeenCalled()
 		expect(player.unregistered).toHaveBeenCalled()
 
+	it 'should ignore bogus unregistration', ->
+		server.handleMessage 'UNREGISTER', ['mallory'], connection
+
 	it 'should reject registrations with invalid player names', ->
 		expectNameToBeRejected ''
 		expectNameToBeRejected 'nameWithSemicolon;'


### PR DESCRIPTION
Prior to this fix, clients were able to stop the server by issuing a "UNREGISTER" request without any previous "REGISTRATION" request. These situtations could, for example, arise when the server is restarted while clients continued running. Once a client stops, it issues an UNREGISTER request that the server could not handle.